### PR TITLE
baseVars/hostVars: use module system instead of specialArgs

### DIFF
--- a/apps/cli/gh.nix
+++ b/apps/cli/gh.nix
@@ -1,4 +1,4 @@
-{ vars, ... }:
+{ config, ... }:
 
 {
   hm =
@@ -10,7 +10,7 @@
 
     programs.gh.settings =
     {
-      editor = vars.editor;
+      editor = config.baseVars.editor;
       git_protocol = "https"; # TODO: make this use ssh when proper secrets are set up
     };
 

--- a/apps/cli/git.nix
+++ b/apps/cli/git.nix
@@ -1,5 +1,5 @@
 {
-  vars,
+  config,
   ...
 }:
 
@@ -7,7 +7,7 @@
   hm.programs.git =
   {
     enable = true;
-    userName = vars.fullName; # Full name associated with commits
+    userName = config.baseVars.fullName; # Full name associated with commits
     userEmail = "78693624+quatquatt@users.noreply.github.com"; # github noreply email
 
     extraConfig =

--- a/apps/gui/steam.nix
+++ b/apps/gui/steam.nix
@@ -1,4 +1,4 @@
-{ pkgs, hostVars, ... }:
+{ pkgs, config, ... }:
 
 {
 
@@ -11,7 +11,7 @@
     gamescopeSession.enable = true;
     package = pkgs.steam.override
     {
-      extraArgs = "-forcedesktopscaling ${toString hostVars.scalingFactor}";
+      extraArgs = "-forcedesktopscaling ${toString config.hostVars.scalingFactor}";
     };
   };
 

--- a/base/baseVars.nix
+++ b/base/baseVars.nix
@@ -1,5 +1,5 @@
 {
-  configDirectory = "/etc/nixos";
-  editor = "nano";
-  fullName = "Eman Resu";
+  baseVars.configDirectory = "/etc/nixos";
+  baseVars.editor = "nano";
+  baseVars.fullName = "Eman Resu";
 }

--- a/base/core/gdm.nix
+++ b/base/core/gdm.nix
@@ -1,4 +1,4 @@
- { hostVars, lib, ... }:
+ { config, lib, ... }:
 
 
 {
@@ -15,7 +15,7 @@
   # services.displayManager.autoLogin =
   # {
   #   enable = true;
-  #   user = hostVars.username;
+  #   user = config.hostVars.username;
   # };
 
   # systemd.services."getty@tty1".enable = false;

--- a/base/core/home-manager.nix
+++ b/base/core/home-manager.nix
@@ -1,5 +1,5 @@
 {
-  hostVars,
+  config,
   lib,
   inputs,
   pkgs,
@@ -10,7 +10,7 @@
   imports =
   [
     inputs.home-manager.nixosModules.home-manager
-    (lib.mkAliasOptionModule ["hm"] ["home-manager" "users" hostVars.username]) # Let us use hm as shorthand for home-manager config
+    (lib.mkAliasOptionModule ["hm"] ["home-manager" "users" config.hostVars.username]) # Let us use hm as shorthand for home-manager config
   ];
 
   environment.systemPackages = with pkgs;
@@ -28,13 +28,13 @@
 
     home =
     {
-      username = hostVars.username;
-      homeDirectory = hostVars.homeDirectory;
-      stateVersion = hostVars.stateVersion;
+      username = config.hostVars.username;
+      homeDirectory = config.hostVars.homeDirectory;
+      stateVersion = config.hostVars.stateVersion;
     };
   };
 
-  home-manager.useUserPackages = true; 
+  home-manager.useUserPackages = true;
   home-manager.useGlobalPkgs = true;
 
 }

--- a/base/core/networking.nix
+++ b/base/core/networking.nix
@@ -1,16 +1,16 @@
-{ hostVars, ... }:
+{ config, ... }:
 
 {
   networking =
   {
-    hostName = hostVars.hostName;
+    hostName = config.hostVars.hostName;
 
     firewall.enable = true;
     resolvconf.dnsExtensionMechanism = false;
   };
 
   networking.networkmanager.enable = true;
-  users.users.${hostVars.username}.extraGroups = [ "networkmanager"]; 
+  users.users.${config.hostVars.username}.extraGroups = [ "networkmanager"];
 
   boot.kernel.sysctl."net.ipv4.ip_forward" = 1;  # Enable ip forwarding
 

--- a/base/core/nix.nix
+++ b/base/core/nix.nix
@@ -1,5 +1,5 @@
 {
-  hostVars,
+  config,
   pkgs,
   pkgs-unstable,
   ...
@@ -37,5 +37,5 @@
 
   documentation.nixos.enable = false; # Apparently speeds up rebuild time
 
-  system.stateVersion = hostVars.stateVersion;
+  system.stateVersion = config.hostVars.stateVersion;
 }

--- a/base/core/user.nix
+++ b/base/core/user.nix
@@ -1,10 +1,10 @@
-{ vars, hostVars, pkgs, ... }:
+{ config, pkgs, ... }:
 
 {
-  users.users.${hostVars.username} =
+  users.users.${config.hostVars.username} =
   {
     isNormalUser = true;
-    description = vars.fullName;
+    description = config.baseVars.fullName;
 
     hashedPassword = "$y$j9T$MGJ3p2bsJzeGrB6.3zN7s.$RobkJp7ROyz3FSS9nDqAp412hjhRuCv/GMaB7Swo8Y5";
     extraGroups = [ "wheel" ];

--- a/base/features/virtualization.nix
+++ b/base/features/virtualization.nix
@@ -1,4 +1,4 @@
-{ pkgs, hostVars, ... }:
+{ pkgs, config, ... }:
 
 {
 
@@ -15,7 +15,7 @@
     enableOnBoot = false;
   };
 
-  users.users.${hostVars.username}.extraGroups = [ "libvirtd ""docker" ];
+  users.users.${config.hostVars.username}.extraGroups = [ "libvirtd ""docker" ];
 
   services.spice-webdavd.enable = true;
 

--- a/base/features/xdg.nix
+++ b/base/features/xdg.nix
@@ -1,4 +1,4 @@
-{ pkgs, hostVars, lib, ... }:
+{ pkgs, config, lib, ... }:
 
 
 {
@@ -26,6 +26,6 @@
       config.common.default = "gnome";
     };
 
-    home.file."${hostVars.homeDirectory}/.config/mimeapps.list".force = lib.mkForce true; # Delete backup for mimeApps since backups are done idiotically
+    home.file."${config.hostVars.homeDirectory}/.config/mimeapps.list".force = lib.mkForce true; # Delete backup for mimeApps since backups are done idiotically
   };
 }

--- a/base/gnome/nautilus.nix
+++ b/base/gnome/nautilus.nix
@@ -1,4 +1,4 @@
-{ vars, hostVars, pkgs, ... }:
+{ config, pkgs, ... }:
 
 {
 
@@ -27,8 +27,8 @@
       gtk3.bookmarks =
       [
         "file:///" # Root
-        "file://${vars.configDirectory}" # nixos config directory
-        "file://${hostVars.homeDirectory}/VMS"
+        "file://${config.baseVars.configDirectory}" # nixos config directory
+        "file://${config.hostVars.homeDirectory}/VMS"
       ];
     };
 

--- a/base/gnome/scaling.nix
+++ b/base/gnome/scaling.nix
@@ -1,17 +1,17 @@
-{ lib, myLib, hostVars, ... }:
+{ lib, myLib, config, ... }:
 
 {
   programs.dconf.profiles.gdm.databases = myLib.mkList # dconf options from nixos, NOT home-manager
   {
     settings."org/gnome/desktop/interface" = # Scaling on login screen
     {
-      scaling-factor = lib.gvariant.mkUint32 hostVars.scalingFactor;
+      scaling-factor = lib.gvariant.mkUint32 config.hostVars.scalingFactor;
     };
   };
 
   hm.dconf.settings."org/gnome/desktop/interface" =
   {
-    scaling-factor = lib.gvariant.mkUint32 hostVars.scalingFactor;
+    scaling-factor = lib.gvariant.mkUint32 config.hostVars.scalingFactor;
   };
 
   hm.xdg.configFile."monitors.xml" = # Delete monitors.xml contents since it overrides any declarative scaling settings

--- a/base/modules/baseVars.nix
+++ b/base/modules/baseVars.nix
@@ -1,0 +1,41 @@
+{ lib, config, ... }:
+let
+  cfg = config.baseVars;
+in
+{
+  options.baseVars =
+  {
+    configDirectory = lib.mkOption
+    {
+      type = lib.types.str;
+      description = "The directory of the local nixos configuration.";
+      default = null;
+    };
+
+    editor = lib.mkOption
+    {
+      type = lib.types.str;
+      description = "Your preferred text editor.";
+      default = null;
+    };
+    fullName = lib.mkOption
+    {
+      type = lib.types.str;
+      description = "Your first and last name.";
+      default = null;
+    };
+  };
+
+  config.assertions =
+  [
+    {
+      assertion = cfg.configDirectory != null;
+    }
+    {
+      assertion = cfg.editor != null;
+    }
+    {
+      assertion = cfg.fullName != null;
+    }
+  ];
+}

--- a/base/modules/hostVars.nix
+++ b/base/modules/hostVars.nix
@@ -1,0 +1,65 @@
+{ lib, config, options, ... }:
+let
+  cfg = config.hostVars;
+in
+{
+  options.hostVars =
+  {
+
+    hostName = lib.mkOption
+    {
+      type = lib.types.str;
+      description = "The hostname for the current host.";
+      default = null;
+    };
+
+    username = lib.mkOption
+    {
+      type = lib.types.str;
+      description = "The username for the current host.";
+      default = null;
+    };
+
+    homeDirectory = lib.mkOption
+    {
+      type = lib.types.str;
+      description = "The directory for the user's folders. This should only be set if it's in a non-default location.";
+      default = "/home/${cfg.username}";
+    };
+
+    scalingFactor = lib.mkOption
+    {
+      type = lib.types.int;
+      description = "The scaling factor for the desktop. A scalingFactor of 1 --> 100% scaling.";
+      default = null;
+    };
+
+    stateVersion = lib.mkOption
+    {
+      type = lib.types.str;
+      description = "The version cycle of NixOS during which this host was installed.";
+      example = "24.05";
+      default = null;
+    };
+  };
+
+
+  config.assertions =
+  [
+    {
+      assertion = options.hostVars.hostName.isDefined;
+    }
+    {
+      assertion = options.hostVars.username.isDefined;
+    }
+    {
+      assertion = options.hostVars.homeDirectory.isDefined;
+    }
+    {
+      assertion = options.hostVars.scalingFactor.isDefined;
+    }
+    {
+      assertion = options.hostVars.stateVersion.isDefined;
+    }
+  ];
+}

--- a/base/terminal/zsh.nix
+++ b/base/terminal/zsh.nix
@@ -1,6 +1,5 @@
 {
-  vars,
-  hostVars,
+  config,
   pkgs,
   ...
 }:
@@ -8,7 +7,7 @@
 {
   programs.zsh.enable = true; # Required to set environment.shells
   environment.shells = with pkgs; [ zsh ];
-  users.users.${hostVars.username}.shell = pkgs.zsh;
+  users.users.${config.hostVars.username}.shell = pkgs.zsh;
 
   hm.programs.zsh =
   {
@@ -19,12 +18,12 @@
     enableCompletion = false;
     autocd = true; # If empty directory given as command, interpret it as cd
 
-    sessionVariables.EDITOR = vars.editor;
+    sessionVariables.EDITOR = config.baseVars.editor;
     shellAliases.src = ". ~/.zshrc";
 
     history =
     {
-      path = "${hostVars.homeDirectory}/.zsh_history";
+      path = "${config.hostVars.homeDirectory}/.zsh_history";
 
       size = 100000;
       save = 100000;
@@ -36,14 +35,14 @@
 
     initExtra =
     ''
-      export CONFIG_DIRECTORY=${vars.configDirectory}
+      export CONFIG_DIRECTORY=${config.baseVars.configDirectory}
       source ${./options.sh}
       source ${./keybinds.sh}
       source ${./rbld.sh}
 
       evalue()
       (
-        nix eval --json "${vars.configDirectory}#nixosConfigurations.${hostVars.hostName}.config.$1" | jq
+        nix eval --json "${config.baseVars.configDirectory}#nixosConfigurations.${config.hostVars.hostName}.config.$1" | jq
       )
     '';
   };

--- a/hosts/framework/frameworkVars.nix
+++ b/hosts/framework/frameworkVars.nix
@@ -1,10 +1,11 @@
 {
-  hostName = "framework";
+  hostVars =
+  {
+    hostName = "framework";
+    username = "emanresu";
 
-  username = "emanresu";
-  homeDirectory = "/home/emanresu";
+    scalingFactor = 2; # 200% scaling
 
-  scalingFactor = 2; # 200% scaling
-
-  stateVersion = "24.05";
+    stateVersion = "24.05";
+  };
 }

--- a/myLib/mkNixos.nix
+++ b/myLib/mkNixos.nix
@@ -18,9 +18,6 @@ let
       inherit inputs myLib;
 
       pkgs-unstable = internals.myUnstablePkgs system;
-
-      vars = import ../base/baseVars.nix;
-      hostVars = import ../hosts/${hostname}/${hostname}Vars.nix;
     };
 
     modules = myLib.importUtils.importAll
@@ -30,12 +27,14 @@ let
       ../base/gnome
       ../base/modules
       ../base/terminal
+      ../base/baseVars.nix
 
       ../apps/cli
       ../apps/gui
 
       ../hosts/${hostname}/modules
       ../hosts/${hostname}/hardware-configuration.nix
+      ../hosts/${hostname}/${hostname}Vars.nix
     ]
     ++
     [


### PR DESCRIPTION
Closes #13. 

Could be made a bit prettier with:
- Creating a `myLib` function for automatic `isDefined` assertions
- Looking into the possibility of aliasing `config.hostVars` to just `hostVars`. 
- moving `configDirectory` to be a host variable since if we ever changed it on one machine, it shouldn't break other systems
- importing `baseVars` and `hostVars` automatically via a fancy `mkNixos` helper function
- Thinking about paradigms that let us access vars regardless of whether they're a `hostVar` or a `baseVar`.

but that can all come in a later commit. For now, this adds the functionality, which is much better than the previous cursed `specialArgs` stuff.